### PR TITLE
Refractor styling for Bank and fix accses issue for theme 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ ReactDOM.render(
   
   <Router>
     <React.StrictMode>
-      <ThemeProvider theme={theme}>
+      <ThemeProvider theme={theme.theme}>
         <App />
       </ThemeProvider>
     </React.StrictMode>

--- a/src/views/cardView.js
+++ b/src/views/cardView.js
@@ -1,33 +1,14 @@
 import React from "react";
 import styled from "styled-components";
 
+
 /*
-Usage notes:
-    The Card component gives the style of the component. It can be combinated with the Translation component
-    however if span is the other component then the margin area of Translation will also be preasable. So dont do that. 
+    CardView
+    Used in boards
+
 */
 
-const Card = styled.div`
-    margin: 2px;
-    padding: 2px;
-`;
-
-const TranslationWrapper = styled.div`
-    display: flex;
-    flex-direction: row;
-    justify-content: space-around;
-`;
-
-const Translation = styled.div`
-    background-color: ${props => (props.isTranslateFrom ? props.theme.fromLanguage : props.theme.toLanguage)};
-    padding: 10px;
-    color: ${props => props.theme.darkText};
-    text-align: center;
-    font-size: 1em;
-    // flex: 0 0 50px;
-    width: 50%;
-    border-radius: ${props => (props.isTranslateFrom ? "5px 0px 0px 5px" : "0px 5px 5px 0px" )}; /* top left, top right, bottom right, bottom left */
-`;
+import { Card, TranslationWrapper, Translation } from "./components"
 
 export default function CardView(props) {
     return (

--- a/src/views/components/index.js
+++ b/src/views/components/index.js
@@ -3,9 +3,10 @@ import { BoardTitle,BoardNameInput,RoundButton } from "./general.js";
 import  Burger from "./burger.js"
 import  Menu  from "./menu.js"
 import  Dropdown  from "./dropdown.js"
-import  DropdownItem  from "./dropdownItem.js"
+import DropdownItem from "./dropdownItem.js"
+import { Card, TranslationWrapper, Translation } from "./translationCard.js";
 
 export {
             BoardWrapper, BoardTitleWrapper, BoardCardWrapper,BoardTitle,BoardNameInput,RoundButton,
-            Menu, Burger, Dropdown, DropdownItem
+            Menu, Burger, Dropdown, DropdownItem, Card, TranslationWrapper, Translation 
         };

--- a/src/views/components/translationCard.js
+++ b/src/views/components/translationCard.js
@@ -1,0 +1,34 @@
+import styled from "styled-components";
+
+/*
+    Styled componets for translation card
+*/
+
+
+/*
+Usage notes:
+    The Card component gives the style of the component. It can be combinated with the Translation component
+    however if span is the other component then the margin area of Translation will also be preasable. So dont do that. 
+*/
+
+export const  Card = styled.div`
+    margin: 2px;
+    padding: 2px;
+`;
+
+export const  TranslationWrapper = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+`;
+
+export const  Translation = styled.div`
+    background-color: ${props => (props.isTranslateFrom ? props.theme.fromLanguage : props.theme.toLanguage)};
+    padding: 10px;
+    color: ${props => props.theme.darkText};
+    text-align: center;
+    font-size: 1em;
+    // flex: 0 0 50px;
+    width: 50%;
+    border-radius: ${props => (props.isTranslateFrom ? "5px 0px 0px 5px" : "0px 5px 5px 0px")}; /* top left, top right, bottom right, bottom left */
+`;


### PR DESCRIPTION
- Moving styled components for Card View to its own map
- Fix issue that changed accses to theme from props.theme to props.theme.theme which was breaking some styling code